### PR TITLE
Ensure that icons are actually utilised

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "webpack": "^4.3.0"
   },
   "devDependencies": {
+    "@mdi/font": "^5.8.55",
+    "@mdi/js": "^5.8.55",
     "@vue/cli-plugin-babel": "^4.4.6",
     "@vue/cli-plugin-eslint": "^4.4.6",
     "@vue/cli-service": "^4.4.6",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -73,6 +73,15 @@ func New(c types.Configer) Server {
 		},
 	)
 
+	g.StaticFS("/fonts",
+		&assetfs.AssetFS{
+			Asset:     Asset,
+			AssetDir:  AssetDir,
+			AssetInfo: AssetInfo,
+			Prefix:    "fonts/",
+		},
+	)
+
 	g.GET("/", index)
 	g.GET("/sources", index)
 	g.GET("/destinations", index)

--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -1,3 +1,4 @@
+import '@mdi/font/css/materialdesignicons.css';
 import Vue from 'vue';
 import Vuetify from 'vuetify/lib';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -889,6 +889,16 @@
     cssnano-preset-default "^4.0.0"
     postcss "^7.0.0"
 
+"@mdi/font@^5.8.55":
+  version "5.8.55"
+  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-5.8.55.tgz#1464155bcbc8a6e4af6dffd611fe8e38e09af285"
+  integrity sha512-8mrwfFBsmj+D67ZiGQSe5TU/lcWCtDyli2eshQ2fvLCZGRPqFMM23YQp4+JMOTpk5yMZKTeAwNWIYfITy76OHA==
+
+"@mdi/js@^5.8.55":
+  version "5.8.55"
+  resolved "https://registry.yarnpkg.com/@mdi/js/-/js-5.8.55.tgz#630bc5fafd8b1d2f6e63489a9ab170177559e41b"
+  integrity sha512-2bvln56SW6V/nSDC/0/NTu1bMF/CgSyZox8mcWbAPWElBN3UYIrukKDUckEER8ifr8X2YJl1RLKQqi7T7qLzmg==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"


### PR DESCRIPTION
Turns out that even though there are default icons, their content actually needs to be explicitly imported and applied.

This also means that as the icons utilise fonts, our backend also needs to serve them.