### PR TITLE
When a Source is a directory specifically, append a slash to not glob beyond the intended scope

### DIFF
--- a/src/components/Destination.vue
+++ b/src/components/Destination.vue
@@ -21,7 +21,9 @@
 
           <v-data-table :headers="headers" :items="destination.entries" :search="search" class="elevation-1">
             <template v-slot:item.action="{ item }">
-              <v-btn block small @click="remove(item.entry)">Remove</v-btn>
+              <v-btn block small @click="remove(item.entry)">
+                <v-icon :icon="`${mdiTrashCanOutline}`"></v-icon> Remove
+              </v-btn>
             </template>
           </v-data-table>
 
@@ -55,12 +57,13 @@
 
 <script>
 import { mapActions, mapMutations, mapGetters } from 'vuex';
-import { mdiArrowRightThinCircleOutline, mdiMagnify } from '@mdi/js';
+import { mdiArrowRightThinCircleOutline, mdiMagnify, mdiTrashCanOutline } from '@mdi/js';
 
 export default {
   data: () => ({
     mdiMagnify,
     mdiArrowRightThinCircleOutline,
+    mdiTrashCanOutline,
     headers: [
       {title: 'Name', align: 'left', key: 'entry'},
       {title: 'Actions', key: 'action'},

--- a/src/components/Source.vue
+++ b/src/components/Source.vue
@@ -21,7 +21,7 @@
 
           <v-data-table-virtual :headers="headersExpanded" :items="source.entries" :search="search" :single-expand="singleExpand" :expanded.sync="expanded" item-value="entry" show-expand class="elevation-1" height="100%" v-if="isExpandable">
             <template v-slot:item.action="{ item }">
-              <CopyDialog :source_name="source.source.name" :entry_name="item.entry" />
+              <CopyDialog :source_name="source.source.name" :entry_name="item.entry + '/'" />
             </template>
             <template v-slot:expanded-row="{ columns,item }">
               <tr>

--- a/src/components/SubSource.vue
+++ b/src/components/SubSource.vue
@@ -1,7 +1,7 @@
 <template>
   <v-data-table :items="sub_source.entries" :items-per-page="0" :headers="headers" hover no-filter disable-pagination hide-default-header>
     <template v-slot:item.action="{ item }">
-      <CopyDialog :source_name="source_name" :entry_name="sub_name + '/' + item.entry" />
+      <CopyDialog :source_name="source_name" :entry_name="sub_name + '/' + item.entry + '/'" />
     </template>
     <template v-slot:headers="{ }"><!-- skip! --></template>
     <template #bottom></template>


### PR DESCRIPTION
Fixes #19 

- Add a trailing slash to copy commands that are presumably directories
- Adding the trash icon on the remove button